### PR TITLE
[Format-Inspector] convert ImageFormatError in post_process to Warnin…

### DIFF
--- a/glance/common/format_inspector.py
+++ b/glance/common/format_inspector.py
@@ -685,15 +685,15 @@ class VMDKInspector(FileInspector):
             '<4sIIQQQQIQQ', self.region('header').data[:64])
 
         if sig != b'KDMV':
-            raise ImageFormatError('Signature KDMV not found: %r' % sig)
+            LOG.warning('Signature KDMV not found: %r - proceeding with limitations.' % sig)
 
         if ver not in (1, 2, 3):
-            raise ImageFormatError('Unsupported format version %i' % ver)
+            LOG.warning('Unsupported format version %i - proceeding with limitations.' % ver)
 
         if gdOffset == self.GD_AT_END:
             # This means we have a footer, which takes precedence over the
             # header, which we cannot support since we stream.
-            raise ImageFormatError('Unsupported VMDK footer')
+            LOG.warning('Unsupported VMDK footer - proceeding with limitations.')
 
         # Since we parse both desc_sec and desc_num (the location of the
         # VMDK's descriptor, expressed in 512 bytes sectors) we enforce a

--- a/glance/common/format_inspector.py
+++ b/glance/common/format_inspector.py
@@ -684,16 +684,20 @@ class VMDKInspector(FileInspector):
          _numGTEsperGT, _rgdOffset, gdOffset) = struct.unpack(
             '<4sIIQQQQIQQ', self.region('header').data[:64])
 
+        # Need to validate why the images are still created if ImageFormatError is raised
         if sig != b'KDMV':
             LOG.warning('Signature KDMV not found: %r - proceeding with limitations.' % sig)
+            return
 
         if ver not in (1, 2, 3):
             LOG.warning('Unsupported format version %i - proceeding with limitations.' % ver)
+            return
 
         if gdOffset == self.GD_AT_END:
             # This means we have a footer, which takes precedence over the
             # header, which we cannot support since we stream.
             LOG.warning('Unsupported VMDK footer - proceeding with limitations.')
+            return
 
         # Since we parse both desc_sec and desc_num (the location of the
         # VMDK's descriptor, expressed in 512 bytes sectors) we enforce a


### PR DESCRIPTION
…g to avoid Sentry alert spam

At the moment the format_inspector only alerts with error message, the below fix will block images in the future :

https://review.opendev.org/c/openstack/glance-specs/+/925111