### PR TITLE
Add implicit_returning=False to metadef table definitions

### DIFF
--- a/glance/db/sqlalchemy/metadata.py
+++ b/glance/db/sqlalchemy/metadata.py
@@ -67,34 +67,62 @@ CONF.register_opts(metadata_opts)
 
 def get_metadef_namespaces_table(meta, conn):
     with conn.begin():
-        return sqlalchemy.Table('metadef_namespaces', meta, autoload_with=conn)
+        return sqlalchemy.Table(
+            'metadef_namespaces',
+            meta,
+            implicit_returning=False,
+            autoload_with=conn
+        )
 
 
 def get_metadef_resource_types_table(meta, conn):
     with conn.begin():
-        return sqlalchemy.Table('metadef_resource_types', meta,
-                                autoload_with=conn)
+        return sqlalchemy.Table(
+            'metadef_resource_types',
+            meta,
+            implicit_returning=False,
+            autoload_with=conn
+        )
 
 
 def get_metadef_namespace_resource_types_table(meta, conn):
     with conn.begin():
-        return sqlalchemy.Table('metadef_namespace_resource_types', meta,
-                                autoload_with=conn)
+        return sqlalchemy.Table(
+            'metadef_namespace_resource_types',
+            meta,
+            implicit_returning=False,
+            autoload_with=conn
+        )
 
 
 def get_metadef_properties_table(meta, conn):
     with conn.begin():
-        return sqlalchemy.Table('metadef_properties', meta, autoload_with=conn)
+        return sqlalchemy.Table(
+            'metadef_properties',
+            meta,
+            implicit_returning=False,
+            autoload_with=conn
+        )
 
 
 def get_metadef_objects_table(meta, conn):
     with conn.begin():
-        return sqlalchemy.Table('metadef_objects', meta, autoload_with=conn)
+        return sqlalchemy.Table(
+            'metadef_objects',
+            meta,
+            implicit_returning=False,
+            autoload_with=conn
+        )
 
 
 def get_metadef_tags_table(meta, conn):
     with conn.begin():
-        return sqlalchemy.Table('metadef_tags', meta, autoload_with=conn)
+        return sqlalchemy.Table(
+            'metadef_tags',
+            meta,
+            implicit_returning=False,
+            autoload_with=conn
+        )
 
 
 def _get_resource_type_id(meta, conn, name):


### PR DESCRIPTION
Add implicit_returning=False to metadef table definitions to avoid RETURNING
statements in queries on DELETE, that is issues at the end of tempest run,
when created metadef namespaces, tags and types are deleted

