### PR TITLE
Add project tags in extra_properties for intial image filtering phase

### DIFF
--- a/glance/api/v2/images.py
+++ b/glance/api/v2/images.py
@@ -97,26 +97,27 @@ class ImagesController(object):
             if 'owner' not in image:
                 image['owner'] = req.context.project_id
 
-            api_policy.ImageAPIPolicy(req.context, image,
-                                    self.policy).add_image()
+            api_policy.ImageAPIPolicy(req.context, image, self.policy).add_image()
 
             ks_quota.enforce_image_count_total(req.context, req.context.owner)
+
+            # ✅ Flatten domain_tags list into comma-separated string
+            tags_list = getattr(req.context, 'domain_tags', None)
+            if tags_list:
+                if isinstance(tags_list, list):
+                    extra_properties['domain_tags'] = ','.join(tags_list)
+                else:
+                    extra_properties['domain_tags'] = str(tags_list)
+                LOG.debug("Attached project tags to image during create (no ID): %s", tags_list)
 
             image = image_factory.new_image(extra_properties=extra_properties,
                                             tags=tags, **image)
 
-            tags_list = getattr(req.context, 'domain_tags', None)
-            if tags_list:
-                image.extra_properties['domain_tags'] = json.dumps(tags_list)
-                LOG.debug("Attached project tags to image during create (no ID): %s", tags_list)
-
             image_repo.add(image)
 
-        except (exception.DuplicateLocation,
-                exception.Invalid) as e:
+        except (exception.DuplicateLocation, exception.Invalid) as e:
             raise webob.exc.HTTPBadRequest(explanation=e.msg)
-        except (exception.ReservedProperty,
-                exception.ReadonlyProperty) as e:
+        except (exception.ReservedProperty, exception.ReadonlyProperty) as e:
             raise webob.exc.HTTPForbidden(explanation=e.msg)
         except exception.Forbidden as e:
             LOG.debug("User not permitted to create image")
@@ -134,7 +135,6 @@ class ImagesController(object):
             raise webob.exc.HTTPBadRequest(explanation=e)
 
         return image
-
 
     def _bust_import_lock(self, admin_image_repo, admin_task_repo,
                           image, task, task_id):
@@ -533,7 +533,6 @@ class ImagesController(object):
             message = _("Invalid value '%s' for 'os_hidden' filter."
                         " Valid values are 'true' or 'false'.") % os_hidden
             raise webob.exc.HTTPBadRequest(explanation=message)
-        # ensure the type of os_hidden is boolean
         filters['os_hidden'] = os_hidden == 'true'
 
         protected = filters.get('protected')
@@ -542,7 +541,6 @@ class ImagesController(object):
                 message = _("Invalid value '%s' for 'protected' filter."
                             " Valid values are 'true' or 'false'.") % protected
                 raise webob.exc.HTTPBadRequest(explanation=message)
-            # ensure the type of protected is boolean
             filters['protected'] = protected == 'true'
 
         if limit is None:
@@ -551,9 +549,6 @@ class ImagesController(object):
 
         image_repo = self.gateway.get_repo(req.context)
         try:
-            # NOTE(danms): This is just a "do you have permission to
-            # list images" check. Each image is checked against
-            # get_image below.
             target = {'project_id': req.context.project_id}
             self.policy.enforce(req.context, 'get_images', target)
 
@@ -568,29 +563,25 @@ class ImagesController(object):
                                                 self.policy
                                                 ).check('get_image')]
 
-            # ✅ Apply domain_tags filter only if domain_name starts with 'iaas'
+            # ✅ Apply domain_tags filter as comma-separated string comparison
             domain_name = getattr(req.context, 'domain_name', None)
             LOG.debug("Request context domain_name: %s", domain_name)
 
-            requested_domain_tags = filters.get('domain_tags', [])
+            requested_domain_tags = filters.get('domain_tags')
+            if requested_domain_tags:
+                if isinstance(requested_domain_tags, str):
+                    requested_domain_tags = [requested_domain_tags]
 
             if domain_name and domain_name.startswith('iaas') and requested_domain_tags:
                 LOG.debug("Filtering images by domain_tags: %s", requested_domain_tags)
                 filtered_images = []
                 for image in images:
-                    image_tags_json = image.extra_properties.get('domain_tags', '[]')
-                    try:
-                        image_domain_tags = json.loads(image_tags_json)
-                    except (ValueError, TypeError):
-                        image_domain_tags = []
+                    image_tags_str = image.extra_properties.get('domain_tags', '')
+                    image_domain_tags = [tag.strip() for tag in image_tags_str.split(',') if tag.strip()]
                     if set(requested_domain_tags).issubset(set(image_domain_tags)):
                         filtered_images.append(image)
                 images = filtered_images
 
-            # NOTE(danms): we need to include the next marker if the DB
-            # paginated. Since we filter images based on policy, we can
-            # not determine if pagination happened from the final list,
-            # so use the original count.
             if len(images) != 0 and db_image_count == limit:
                 result['next_marker'] = images[-1].image_id
 
@@ -608,6 +599,7 @@ class ImagesController(object):
         result['images'] = images
         return result
 
+
     def show(self, req, image_id):
         image_repo = self.gateway.get_repo(req.context)
         try:
@@ -616,7 +608,10 @@ class ImagesController(object):
 
             if getattr(CONF, 'show_domain_tags', False):
                 tags = utils.fetch_domain_tags(image.owner, auth_token=req.context.auth_token)
-                image.extra_properties['domain_tags'] = tags
+                if isinstance(tags, list):
+                    image.extra_properties['domain_tags'] = ','.join(tags)
+                else:
+                    image.extra_properties['domain_tags'] = str(tags)
                 LOG.debug("Attached project tags to image %s: %s", image_id, tags)
 
             return image
@@ -625,6 +620,7 @@ class ImagesController(object):
             raise webob.exc.HTTPNotFound(explanation=e.msg)
         except exception.NotAuthenticated as e:
             raise webob.exc.HTTPUnauthorized(explanation=e.msg)
+
 
     def get_task_info(self, req, image_id):
         image_repo = self.gateway.get_repo(req.context)
@@ -1757,17 +1753,24 @@ class ResponseSerializer(wsgi.JSONResponseSerializer):
 
         try:
             image_view = {k: v for k, v in dict(image.extra_properties).items()
-                          if k not in self._hidden_properties}
+                        if k not in self._hidden_properties}
             attributes = ['name', 'disk_format', 'container_format',
-                          'visibility', 'size', 'virtual_size', 'status',
-                          'checksum', 'protected', 'min_ram', 'min_disk',
-                          'owner', 'os_hidden', 'os_hash_algo',
-                          'os_hash_value']
+                        'visibility', 'size', 'virtual_size', 'status',
+                        'checksum', 'protected', 'min_ram', 'min_disk',
+                        'owner', 'os_hidden', 'os_hash_algo',
+                        'os_hash_value']
             for key in attributes:
                 image_view[key] = getattr(image, key)
             image_view['id'] = image.image_id
             image_view['created_at'] = timeutils.isotime(image.created_at)
             image_view['updated_at'] = timeutils.isotime(image.updated_at)
+
+            # ✅ Convert domain_tags to string if it's a list
+            if 'domain_tags' in image_view:
+                domain_tags = image_view['domain_tags']
+                if isinstance(domain_tags, list):
+                    domain_tags = ','.join(domain_tags)
+                image_view['domain_tags'] = domain_tags
 
             if CONF.show_multiple_locations:
                 locations = _get_image_locations(image)
@@ -1779,31 +1782,26 @@ class ResponseSerializer(wsgi.JSONResponseSerializer):
                         tmp.pop('status', None)
                         image_view['locations'].append(tmp)
                 else:
-                    # NOTE (flwang): We will still show "locations": [] if
-                    # image.locations is None to indicate it's allowed to show
-                    # locations but it's just non-existent.
                     image_view['locations'] = []
                     LOG.debug("The 'locations' list of image %s is empty",
-                              image.image_id)
+                            image.image_id)
 
             if CONF.show_image_direct_url:
                 locations = _get_image_locations(image)
                 if locations:
-                    # Choose best location configured strategy
                     loc = utils.sort_image_locations(locations)[0]
                     image_view['direct_url'] = loc['url']
                 else:
                     LOG.debug("The 'locations' list of image %s is empty, "
-                              "not including 'direct_url' in response",
-                              image.image_id)
+                            "not including 'direct_url' in response",
+                            image.image_id)
 
             image_view['tags'] = list(image.tags)
             image_view['self'] = self._get_image_href(image)
             image_view['file'] = self._get_image_href(image, 'file')
             image_view['schema'] = '/v2/schemas/image'
-            image_view = self.schema.filter(image_view)  # domain
+            image_view = self.schema.filter(image_view)
 
-            # add store information to image
             if CONF.enabled_backends:
                 locations = _get_image_locations(image)
                 if locations:
@@ -1812,13 +1810,13 @@ class ResponseSerializer(wsgi.JSONResponseSerializer):
                         backend = loc['metadata'].get('store')
                         if backend:
                             stores.append(backend)
-
                     if stores:
                         image_view['stores'] = ",".join(stores)
 
             return image_view
         except exception.Forbidden as e:
             raise webob.exc.HTTPForbidden(explanation=e.msg)
+
 
     def create(self, response, image):
         response.status_int = http.CREATED

--- a/glance/api/v2/images.py
+++ b/glance/api/v2/images.py
@@ -517,10 +517,10 @@ class ImagesController(object):
 
         return image_id
 
-    def index(self, req, marker=None, limit=None, sort_key=None,
-              sort_dir=None, filters=None, member_status='accepted'):
-        sort_key = ['created_at'] if not sort_key else sort_key
 
+    def index(self, req, marker=None, limit=None, sort_key=None,
+            sort_dir=None, filters=None, member_status='accepted'):
+        sort_key = ['created_at'] if not sort_key else sort_key
         sort_dir = ['desc'] if not sort_dir else sort_dir
 
         result = {}
@@ -558,15 +558,34 @@ class ImagesController(object):
             self.policy.enforce(req.context, 'get_images', target)
 
             images = image_repo.list(marker=marker, limit=limit,
-                                     sort_key=sort_key,
-                                     sort_dir=sort_dir,
-                                     filters=filters,
-                                     member_status=member_status)
+                                    sort_key=sort_key,
+                                    sort_dir=sort_dir,
+                                    filters=filters,
+                                    member_status=member_status)
             db_image_count = len(images)
             images = [image for image in images
-                      if api_policy.ImageAPIPolicy(req.context, image,
-                                                   self.policy
-                                                   ).check('get_image')]
+                    if api_policy.ImageAPIPolicy(req.context, image,
+                                                self.policy
+                                                ).check('get_image')]
+
+            # ✅ Apply domain_tags filter only if domain_name starts with 'iaas'
+            domain_name = getattr(req.context, 'domain_name', None)
+            LOG.debug("Request context domain_name: %s", domain_name)
+
+            requested_domain_tags = filters.get('domain_tags', [])
+
+            if domain_name and domain_name.startswith('iaas') and requested_domain_tags:
+                LOG.debug("Filtering images by domain_tags: %s", requested_domain_tags)
+                filtered_images = []
+                for image in images:
+                    image_tags_json = image.extra_properties.get('domain_tags', '[]')
+                    try:
+                        image_domain_tags = json.loads(image_tags_json)
+                    except (ValueError, TypeError):
+                        image_domain_tags = []
+                    if set(requested_domain_tags).issubset(set(image_domain_tags)):
+                        filtered_images.append(image)
+                images = filtered_images
 
             # NOTE(danms): we need to include the next marker if the DB
             # paginated. Since we filter images based on policy, we can
@@ -574,6 +593,7 @@ class ImagesController(object):
             # so use the original count.
             if len(images) != 0 and db_image_count == limit:
                 result['next_marker'] = images[-1].image_id
+
         except (exception.NotFound, exception.InvalidSortKey,
                 exception.InvalidFilterRangeValue,
                 exception.InvalidParameterValue,
@@ -584,6 +604,7 @@ class ImagesController(object):
             raise webob.exc.HTTPForbidden(explanation=e.msg)
         except exception.NotAuthenticated as e:
             raise webob.exc.HTTPUnauthorized(explanation=e.msg)
+
         result['images'] = images
         return result
 

--- a/glance/api/v2/images.py
+++ b/glance/api/v2/images.py
@@ -581,9 +581,15 @@ class ImagesController(object):
         image_repo = self.gateway.get_repo(req.context)
         try:
             image = image_repo.get(image_id)
-            api_policy.ImageAPIPolicy(req.context, image,
-                                      self.policy).get_image()
+            api_policy.ImageAPIPolicy(req.context, image, self.policy).get_image()
+
+            if getattr(CONF, 'show_project_tags', False):
+                tags = utils.fetch_project_tags(image.owner, auth_token=req.context.auth_token)
+                image.extra_properties['project_tags'] = tags
+                LOG.debug("Attached project tags to image %s: %s", image_id, tags)
+
             return image
+
         except exception.NotFound as e:
             raise webob.exc.HTTPNotFound(explanation=e.msg)
         except exception.NotAuthenticated as e:

--- a/glance/api/v2/images.py
+++ b/glance/api/v2/images.py
@@ -19,6 +19,7 @@ import os
 import re
 import urllib.parse as urlparse
 import uuid
+import json
 
 from castellan.common import exception as castellan_exception
 from castellan import key_manager
@@ -97,12 +98,20 @@ class ImagesController(object):
                 image['owner'] = req.context.project_id
 
             api_policy.ImageAPIPolicy(req.context, image,
-                                      self.policy).add_image()
+                                    self.policy).add_image()
 
             ks_quota.enforce_image_count_total(req.context, req.context.owner)
+
             image = image_factory.new_image(extra_properties=extra_properties,
                                             tags=tags, **image)
+
+            tags_list = getattr(req.context, 'domain_tags', None)
+            if tags_list:
+                image.extra_properties['domain_tags'] = json.dumps(tags_list)
+                LOG.debug("Attached project tags to image during create (no ID): %s", tags_list)
+
             image_repo.add(image)
+
         except (exception.DuplicateLocation,
                 exception.Invalid) as e:
             raise webob.exc.HTTPBadRequest(explanation=e.msg)
@@ -125,6 +134,7 @@ class ImagesController(object):
             raise webob.exc.HTTPBadRequest(explanation=e)
 
         return image
+
 
     def _bust_import_lock(self, admin_image_repo, admin_task_repo,
                           image, task, task_id):
@@ -583,9 +593,9 @@ class ImagesController(object):
             image = image_repo.get(image_id)
             api_policy.ImageAPIPolicy(req.context, image, self.policy).get_image()
 
-            if getattr(CONF, 'show_project_tags', False):
-                tags = utils.fetch_project_tags(image.owner, auth_token=req.context.auth_token)
-                image.extra_properties['project_tags'] = tags
+            if getattr(CONF, 'show_domain_tags', False):
+                tags = utils.fetch_domain_tags(image.owner, auth_token=req.context.auth_token)
+                image.extra_properties['domain_tags'] = tags
                 LOG.debug("Attached project tags to image %s: %s", image_id, tags)
 
             return image

--- a/glance/common/config.py
+++ b/glance/common/config.py
@@ -29,21 +29,21 @@ from paste import deploy
 from glance.i18n import _
 from glance.version import version_info as version
 
-show_project_tags_opt = cfg.BoolOpt(
-    "show_project_tags",
+show_domain_tags_opt = cfg.BoolOpt(
+    "show_domain_tags",
     default=False,
     help="""
 Enable showing Keystone project tags in image details.
 
 When enabled, the Glance API will attempt to fetch the project's tags
 from Keystone and include them in the image's extra_properties
-under the 'project_tags' key. This may result in additional
+under the 'domain_tags' key. This may result in additional
 API calls to Keystone, depending on configuration.
 """,
 )
 
 CONF = cfg.CONF
-CONF.register_opt(show_project_tags_opt)
+CONF.register_opt(show_domain_tags_opt)
 
 # Glance Service User group and options
 glance_service_user_group = cfg.OptGroup(

--- a/glance/common/config.py
+++ b/glance/common/config.py
@@ -29,6 +29,41 @@ from paste import deploy
 from glance.i18n import _
 from glance.version import version_info as version
 
+show_project_tags_opt = cfg.BoolOpt(
+    "show_project_tags",
+    default=False,
+    help="""
+Enable showing Keystone project tags in image details.
+
+When enabled, the Glance API will attempt to fetch the project's tags
+from Keystone and include them in the image's extra_properties
+under the 'project_tags' key. This may result in additional
+API calls to Keystone, depending on configuration.
+""",
+)
+
+CONF = cfg.CONF
+CONF.register_opt(show_project_tags_opt)
+
+# Glance Service User group and options
+glance_service_user_group = cfg.OptGroup(
+    name="glance_service_user",
+    title="Glance Service User Options",
+    help="Options for the service user that Glance can use to fetch project tags or interact with Keystone.",
+)
+
+glance_service_user_opts = [
+    cfg.StrOpt("username", help="Service user name"),
+    cfg.StrOpt('password', secret=True, help='Service user password'),
+    cfg.StrOpt("user_domain_name", default="Default", help="User domain name"),
+    cfg.StrOpt("project_name", help="Service user project name"),
+    cfg.StrOpt("project_domain_name", default="Default", help="Project domain name"),
+    cfg.BoolOpt("enabled", default=False, help="Enable service user integration"),
+]
+
+CONF.register_group(glance_service_user_group)
+CONF.register_opts(glance_service_user_opts, group="glance_service_user")
+
 paste_deploy_opts = [
     cfg.StrOpt('flavor',
                sample_default='keystone',

--- a/glance/common/utils.py
+++ b/glance/common/utils.py
@@ -46,6 +46,9 @@ from glance.common import timeutils
 from glance.common import wsgi
 from glance.i18n import _, _LE, _LW
 
+from keystoneauth1 import loading, session
+from keystoneclient.v3 import client as keystone_client
+
 CONF = cfg.CONF
 
 LOG = logging.getLogger(__name__)
@@ -65,6 +68,67 @@ IMAGE_META_HEADERS = ['x-image-meta-location', 'x-image-meta-size',
 
 GLANCE_TEST_SOCKET_FD_STR = 'GLANCE_TEST_SOCKET_FD'
 
+def fetch_project_tags(project_id, auth_token=None):
+    try:
+        LOG.debug("Starting fetch_project_tags for project_id=%s", project_id)
+
+        if CONF.glance_service_user.enabled:
+            LOG.debug("Using service user flow")
+            LOG.debug(
+                "Service user details: username=%s, user_domain=%s, project=%s, project_domain=%s",
+                CONF.glance_service_user.username,
+                CONF.glance_service_user.user_domain_name,
+                CONF.glance_service_user.project_name,
+                CONF.glance_service_user.project_domain_name,
+            )
+
+            loader = loading.get_plugin_loader("password")
+            auth = loader.load_from_options(
+                auth_url=CONF.keystone_authtoken.auth_url,
+                username=CONF.glance_service_user.username,
+                password=CONF.glance_service_user.password,
+                user_domain_name=CONF.glance_service_user.user_domain_name,
+                project_name=CONF.glance_service_user.project_name,
+                project_domain_name=CONF.glance_service_user.project_domain_name,
+            )
+            sess = session.Session(auth=auth)
+            keystone = keystone_client.Client(session=sess)
+
+        else:
+            LOG.debug("Using user token flow")
+
+            if not auth_token:
+                LOG.error("No auth_token provided in user token flow")
+                raise Exception("No auth token provided for user token mode")
+
+            LOG.debug("Auth token (masked): ****%s", auth_token[-8:])
+            sess = session.Session(auth=None, token=auth_token)
+            keystone = keystone_client.Client(
+                session=sess, endpoint=CONF.keystone_authtoken.auth_url
+            )
+
+        LOG.debug("Calling keystone.projects.list_tags(project_id=%s)", project_id)
+        tags_response = keystone.projects.list_tags(project_id)
+
+        LOG.debug("Raw tags_response type=%s value=%s", type(tags_response), tags_response)
+
+        tags = (
+            tags_response.get("tags", tags_response)
+            if isinstance(tags_response, dict)
+            else tags_response
+        )
+
+        LOG.debug("Extracted tags: %s", tags)
+        return tags
+
+    except Exception as e:
+        LOG.warning(
+            "Failed to fetch project tags for project %s: %s",
+            project_id,
+            e,
+            exc_info=True,
+        )
+        return []
 
 def chunkreadable(iter, chunk_size=65536):
     """

--- a/glance/common/utils.py
+++ b/glance/common/utils.py
@@ -68,20 +68,12 @@ IMAGE_META_HEADERS = ['x-image-meta-location', 'x-image-meta-size',
 
 GLANCE_TEST_SOCKET_FD_STR = 'GLANCE_TEST_SOCKET_FD'
 
-def fetch_project_tags(project_id, auth_token=None):
+def fetch_domain_tags(project_id, auth_token=None):
     try:
-        LOG.debug("Starting fetch_project_tags for project_id=%s", project_id)
+        LOG.debug("Starting fetch_domain_tags for project_id=%s", project_id)
 
+        # Setup Keystone client
         if CONF.glance_service_user.enabled:
-            LOG.debug("Using service user flow")
-            LOG.debug(
-                "Service user details: username=%s, user_domain=%s, project=%s, project_domain=%s",
-                CONF.glance_service_user.username,
-                CONF.glance_service_user.user_domain_name,
-                CONF.glance_service_user.project_name,
-                CONF.glance_service_user.project_domain_name,
-            )
-
             loader = loading.get_plugin_loader("password")
             auth = loader.load_from_options(
                 auth_url=CONF.keystone_authtoken.auth_url,
@@ -93,22 +85,26 @@ def fetch_project_tags(project_id, auth_token=None):
             )
             sess = session.Session(auth=auth)
             keystone = keystone_client.Client(session=sess)
-
         else:
-            LOG.debug("Using user token flow")
-
             if not auth_token:
-                LOG.error("No auth_token provided in user token flow")
                 raise Exception("No auth token provided for user token mode")
-
-            LOG.debug("Auth token (masked): ****%s", auth_token[-8:])
             sess = session.Session(auth=None, token=auth_token)
             keystone = keystone_client.Client(
                 session=sess, endpoint=CONF.keystone_authtoken.auth_url
             )
 
-        LOG.debug("Calling keystone.projects.list_tags(project_id=%s)", project_id)
-        tags_response = keystone.projects.list_tags(project_id)
+        # Step 1: Get domain_id from project
+        project = keystone.projects.get(project_id)
+        domain_id = getattr(project, "domain_id", None)
+        if not domain_id:
+            LOG.warning("Project %s has no domain_id", project_id)
+            return []
+
+        LOG.debug("Extracted domain_id=%s from project_id=%s", domain_id, project_id)
+
+        # Step 2: Try to list tags on domain_id (as project)
+        LOG.debug("Calling keystone.projects.list_tags(domain_id=%s)", domain_id)
+        tags_response = keystone.projects.list_tags(domain_id)
 
         LOG.debug("Raw tags_response type=%s value=%s", type(tags_response), tags_response)
 
@@ -118,17 +114,19 @@ def fetch_project_tags(project_id, auth_token=None):
             else tags_response
         )
 
-        LOG.debug("Extracted tags: %s", tags)
+        LOG.debug("Extracted tags from domain_id: %s", tags)
         return tags
 
     except Exception as e:
         LOG.warning(
-            "Failed to fetch project tags for project %s: %s",
+            "Failed to fetch domain tags using project_id=%s domain_id=%s: %s",
             project_id,
+            domain_id,
             e,
             exc_info=True,
         )
         return []
+
 
 def chunkreadable(iter, chunk_size=65536):
     """

--- a/glance/tests/unit/common/test_utils.py
+++ b/glance/tests/unit/common/test_utils.py
@@ -845,6 +845,14 @@ class TestUtils(test_utils.BaseTestCase):
         loc_url = BASE_URI
         self.assertTrue(utils.is_http_store_configured(loc_url))
 
+    def test_fetch_project_tags_service_user_disabled(self):
+        with mock.patch('glance.common.utils.keystone_client.Client') as mock_client:
+            self.config(enabled=False, group='glance_service_user')
+            context = mock.Mock(auth_token='fake-token')
+            mock_client.return_value.projects.list_tags.return_value = {'tags': ['foo', 'bar']}
+
+            tags = utils.fetch_project_tags('project-id', auth_token='fake-token')
+            self.assertEqual(['foo', 'bar'], tags)
 
 class SplitFilterOpTestCase(test_utils.BaseTestCase):
 


### PR DESCRIPTION
- use service user for now since user_context is restricted by keystone policy
- set the below in glance.conf

```
show_project_tags = True

[glance_service_user]
enabled = true
auth_url = xxx
username = xxx
password = xxx
user_domain_name = xxx
project_name = xxx
project_domain_name = xxx
```