### PR TITLE
[Glance] add s3 python library boto3 to custom-requirements.txt

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,5 +1,6 @@
 paste
 python_swiftclient
+boto3
 
 git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven
 git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware


### PR DESCRIPTION
required to enable s3 multistore