### PR TITLE
[SAP] Fix set_acls when store metadata is missing

### DIFF
--- a/glance/location.py
+++ b/glance/location.py
@@ -68,6 +68,15 @@ class ImageRepoProxy(glance.domain.proxy.Repo):
                 # that image location is present but the actual store is
                 # not related to this node.
                 image_store = location['metadata'].get('store')
+                # NOTE(sapcc): If store metadata is missing, try to derive
+                # it from the location URI. This can happen for images
+                # created before multi-store was enabled.
+                if not image_store:
+                    image_store = store_utils._get_store_id_from_uri(
+                        location['url'])
+                    if image_store:
+                        LOG.debug("Derived store '%s' from URI for image %s",
+                                  image_store, image.image_id)
                 if image_store not in CONF.enabled_backends:
                     msg = (_("Store %s is not available on "
                              "this node, skipping `_set_acls` "
@@ -750,6 +759,15 @@ class ImageMemberRepoProxy(glance.domain.proxy.Repo):
                     # deployment that image location is present but the actual
                     # store is not related to this node.
                     image_store = location['metadata'].get('store')
+                    # NOTE(sapcc): If store metadata is missing, try to derive
+                    # it from the location URI. This can happen for images
+                    # created before multi-store was enabled.
+                    if not image_store:
+                        image_store = store_utils._get_store_id_from_uri(
+                            location['url'])
+                        if image_store:
+                            LOG.debug("Derived store '%s' from URI for image "
+                                      "%s", image_store, self.image.image_id)
                     if image_store not in CONF.enabled_backends:
                         msg = (_("Store %s is not available on "
                                  "this node, skipping `_set_acls` "


### PR DESCRIPTION
When multi-store is enabled, the _set_acls() methods in ImageRepoProxy and ImageMemberRepoProxy require the 'store' key in location metadata. However, for images created before multi-store was enabled, or images that haven't been retrieved via get() since multi-store was enabled, this metadata may be missing (None).

This causes the ACL setting to be silently skipped with the log message: 'Store None is not available on this node, skipping _set_acls call.'

This fix adds a fallback to derive the store identifier from the location URI using _get_store_id_from_uri() when the metadata is missing, ensuring that Swift container ACLs are properly set when images are shared.