### PR TITLE
Fix Swift multi-tenant URL matching

### DIFF
--- a/glance/common/store_utils.py
+++ b/glance/common/store_utils.py
@@ -155,26 +155,27 @@ def validate_external_location(uri):
             scheme not in RESTRICTED_URI_SCHEMAS)
 
 
-def _get_store_id_from_uri(uri):
+def _get_store_id_from_uri(uri, context=None):
     scheme = urlparse.urlparse(uri).scheme
     location_map = store_api.location.SCHEME_TO_CLS_BACKEND_MAP
-    url_matched = False
     if scheme not in location_map:
         LOG.warning("Unknown scheme '%(scheme)s' found in uri '%(uri)s'", {
             'scheme': scheme, 'uri': uri})
         return
+
+    matches = []
     for store in location_map[scheme]:
         store_instance = location_map[scheme][store]['store']
-        url_prefix = store_instance.url_prefix
-        if url_prefix and uri.startswith(url_prefix):
-            url_matched = True
-            break
+        if store_instance.matches_uri(uri, context=context):
+            matches.append(store)
 
-    if url_matched:
-        return u"%s" % store
+    if len(matches) == 1:
+        return u"%s" % matches[0]
+    elif len(matches) > 1:
+        LOG.warning("Multiple stores matched uri '%s': %s", uri, matches)
     else:
-        LOG.warning("Invalid location uri %s", uri)
-        return
+        LOG.warning("Invalid location uri '%s'", uri)
+    return
 
 
 def update_store_in_locations(context, image, image_repo):
@@ -186,7 +187,7 @@ def update_store_in_locations(context, image, image_repo):
             if loc['url'].startswith("cinder://"):
                 _update_cinder_location_and_store_id(context, loc)
 
-            store_id = _get_store_id_from_uri(loc['url'])
+            store_id = _get_store_id_from_uri(loc['url'], context=context)
             if store_id:
                 if 'store' in loc['metadata']:
                     old_store = loc['metadata']['store']
@@ -348,7 +349,7 @@ def get_updated_store_location(locations, context=None):
             _update_cinder_location_and_store_id(context, loc)
             continue
 
-        store_id = _get_store_id_from_uri(loc['url'])
+        store_id = _get_store_id_from_uri(loc['url'], context=context)
         if store_id:
             loc['metadata']['store'] = store_id
 

--- a/glance/location.py
+++ b/glance/location.py
@@ -73,7 +73,7 @@ class ImageRepoProxy(glance.domain.proxy.Repo):
                 # created before multi-store was enabled.
                 if not image_store:
                     image_store = store_utils._get_store_id_from_uri(
-                        location['url'])
+                        location['url'], context=self.context)
                     if image_store:
                         LOG.debug("Derived store '%s' from URI for image %s",
                                   image_store, image.image_id)
@@ -764,7 +764,7 @@ class ImageMemberRepoProxy(glance.domain.proxy.Repo):
                     # created before multi-store was enabled.
                     if not image_store:
                         image_store = store_utils._get_store_id_from_uri(
-                            location['url'])
+                            location['url'], context=self.context)
                         if image_store:
                             LOG.debug("Derived store '%s' from URI for image "
                                       "%s", image_store, self.image.image_id)

--- a/glance/tests/unit/common/test_utils.py
+++ b/glance/tests/unit/common/test_utils.py
@@ -21,6 +21,7 @@ import tempfile
 from unittest import mock
 from urllib.parse import urlparse
 
+import ddt
 import glance_store as store
 from glance_store._drivers import cinder
 from oslo_config import cfg
@@ -39,6 +40,7 @@ CONF = cfg.CONF
 BASE_URI = unit_test_utils.BASE_URI
 
 
+@ddt.ddt
 class TestStoreUtils(test_utils.BaseTestCase):
     """Test glance.common.store_utils module"""
 
@@ -98,6 +100,61 @@ class TestStoreUtils(test_utils.BaseTestCase):
         self.config(enabled_backends=enabled_backends)
         self._test_update_store_in_location({}, None, None,
                                             save_call_count=0)
+
+    @ddt.data(
+        # (scheme_map, uri, expected_store_id, expected_warning_substr)
+        # Unknown scheme returns None
+        ({'rbd': {
+            'ceph1': {'store': mock.Mock(
+                matches_uri=mock.Mock(return_value=True))}}},
+         'ftp://host/file', None, "Unknown scheme"),
+        # Single match returns store id
+        ({'rbd': {
+            'ceph1': {'store': mock.Mock(
+                matches_uri=mock.Mock(return_value=True))}}},
+         'rbd://ceph1/pool/image', 'ceph1', None),
+        # No match returns None
+        ({'rbd': {
+            'ceph1': {'store': mock.Mock(
+                matches_uri=mock.Mock(return_value=False))}}},
+         'rbd://ceph1/pool/image', None, "Invalid location uri"),
+        # Multiple matches returns None
+        ({'rbd': {
+            'ceph1': {'store': mock.Mock(
+                matches_uri=mock.Mock(return_value=True))},
+            'ceph2': {'store': mock.Mock(
+                matches_uri=mock.Mock(return_value=True))}}},
+         'rbd://ceph1/pool/image', None, "Multiple stores matched uri"),
+        # Multiple stores, one match returns correct id
+        ({'rbd': {
+            'ceph1': {'store': mock.Mock(
+                matches_uri=mock.Mock(return_value=False))},
+            'ceph2': {'store': mock.Mock(
+                matches_uri=mock.Mock(return_value=True))}}},
+         'rbd://ceph2/pool/image', 'ceph2', None),
+    )
+    @ddt.unpack
+    @mock.patch.object(store_utils, 'LOG')
+    @mock.patch.object(store_utils, 'store_api')
+    def test_get_store_id_from_uri(self, scheme_map, uri, expected_store_id,
+                                   expected_warning_substr, mock_store_api,
+                                   mock_log):
+        mock_store_api.location.SCHEME_TO_CLS_BACKEND_MAP = scheme_map
+        context = mock.Mock()
+        result = store_utils._get_store_id_from_uri(uri, context=context)
+        self.assertEqual(expected_store_id, result)
+        if expected_warning_substr:
+            mock_log.warning.assert_called_once()
+            self.assertIn(expected_warning_substr,
+                          mock_log.warning.call_args[0][0])
+        else:
+            mock_log.warning.assert_not_called()
+        # Verify context is forwarded to every store's matches_uri
+        scheme = uri.split(':')[0]
+        if scheme in scheme_map:
+            for store_entry in scheme_map[scheme].values():
+                store_entry['store'].matches_uri.assert_called_with(
+                    uri, context=context)
 
 
 class TestCinderStoreUtils(base.MultiStoreClearingUnitTest):
@@ -1391,11 +1448,14 @@ class S3CredentialUpdateTestCase(test_utils.BaseTestCase):
             "Unknown scheme '%(scheme)s' found in uri",
             {'scheme': 's3'})
 
+    @mock.patch('glance.common.store_utils._get_store_id_from_uri',
+                return_value=None)
     @mock.patch('glance.common.store_utils.store_api')
     @mock.patch('glance.common.store_utils.CONF')
     @mock.patch('glance.common.store_utils.LOG')
     def test_update_s3_credentials_no_matching_store(
-            self, mock_log, mock_conf, mock_store_api):
+            self, mock_log, mock_conf, mock_store_api,
+            mock_get_store_id):
         """Test when no S3 store matches the bucket."""
         # Configure stores but with different buckets
         stores = {
@@ -1426,14 +1486,9 @@ class S3CredentialUpdateTestCase(test_utils.BaseTestCase):
             self.context, self.image, self.image_repo)
         # URL should remain unchanged
         self.assertEqual(location['url'], original_url)
-        expected_calls = [
-            mock.call("Invalid location uri %s",
-                      's3://old_key:old_secret@s3.amazonaws.com/'
-                      'unknown-bucket/object'),
-            mock.call("No S3 store found for image %(image_id)s",
-                      {'image_id': 'object'})
-        ]
-        mock_log.warning.assert_has_calls(expected_calls)
+        mock_log.warning.assert_called_once_with(
+            "No S3 store found for image %(image_id)s",
+            {'image_id': 'object'})
 
     @mock.patch('glance.common.store_utils.store_api')
     @mock.patch('glance.common.store_utils.CONF')


### PR DESCRIPTION
_THIS FIRST REQUIRES https://github.com/sapcc/glance_store/pull/21 TO BE MERGED TO GLANCE_STORE. THE MERGE IS ALSO REQUIRED FOR THE TESTS TO RUN THROUGH_

`_get_store_id_from_uri()` matched image location URIs to stores via `url_prefix`. For Swift multi-tenant stores, `url_prefix` may be unavailable and does not include the URL's `container` segment.

We therefore switch to using Glance Store's new `matches_uri` function which implements custom matching for the Swift multi-tenant stores and the current prefix matching for all other stores.

Since the matching for the Swift multi-tenant store is best-effort and not precise, we do not break on the first match but check all stores to ensure that exactly one store matches.